### PR TITLE
[SPARK-14660] Cancel stage doesn't always issue taskEnd event.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1131,6 +1131,11 @@ class DAGScheduler(
 
     if (!stageIdToStage.contains(task.stageId)) {
       // Skip all the actions if the stage has been cancelled.
+        if(event.reason == Success) { 
+            val attemptId = task.stageAttemptId 
+            listenerBus.post(SparkListenerTaskEnd(stageId, attemptId, taskType, event.reason,
+                event.taskInfo, event.taskMetrics)) 
+        }
       return
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handled a taskEnd event case which was not handled hitherto.
## How was this patch tested?

unit tests

(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

If any task is finished in the taskset before the handleTaskCompletion is called, the endTask Event is not issued and the driver can never know if the executor is idle since it always shows some active tasks which aren't actually there.
